### PR TITLE
SCR annotations - minor fixes and merge with trunk

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ImmutableRoot.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ImmutableRoot.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexProvider;
+import org.apache.jackrabbit.oak.plugins.tree.ReadOnly;
 import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
 import org.apache.jackrabbit.oak.query.ExecutionContext;
 import org.apache.jackrabbit.oak.query.QueryEngineImpl;
@@ -44,7 +45,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
  * passed to the constructor. This root implementation provides a query engine
  * with index support limited to the {@link PropertyIndexProvider}.
  */
-public final class ImmutableRoot implements Root {
+public final class ImmutableRoot implements Root, ReadOnly {
 
     private final ImmutableTree rootTree;
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/ChildOrderConflictHandler.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/ChildOrderConflictHandler.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyBuilder;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.commit.PartialConflictHandler;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -31,7 +31,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
  * This conflict handler instance takes care of properly merging conflicts
  * occurring by concurrent reorder operations.
  *
- * @see org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER
+ * @see TreeConstants#OAK_CHILD_ORDER
  */
 public class ChildOrderConflictHandler implements PartialConflictHandler {
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/MergingNodeStateDiff.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/MergingNodeStateDiff.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.json.JsopDiff;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyBuilder;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.commit.ThreeWayConflictHandler.Resolution;
 import org.apache.jackrabbit.oak.spi.commit.ThreeWayConflictHandler;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/AbstractDecoratedNodeState.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/AbstractDecoratedNodeState.java
@@ -39,7 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static com.google.common.base.Predicates.notNull;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
 public abstract class AbstractDecoratedNodeState extends AbstractNodeState {
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
@@ -23,7 +23,7 @@ import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 import static org.apache.jackrabbit.oak.spi.state.MoveDetector.SOURCE_PATH;
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/ReadOnly.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/ReadOnly.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.3.0")
 package org.apache.jackrabbit.oak.plugins.tree;
 
-import org.osgi.annotation.versioning.Version;
+/**
+ * Marker interface to indicate if a {@link Tree} or {@link org.apache.jackrabbit.oak.api.Root}
+ * can only be read (write operations not implemented).
+ */
+public interface ReadOnly {
+}

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeConstants.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeConstants.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.3.0")
 package org.apache.jackrabbit.oak.plugins.tree;
 
-import org.osgi.annotation.versioning.Version;
+public interface TreeConstants {
+
+    /**
+     * Name of the internal property that contains the child order
+     */
+    String OAK_CHILD_ORDER = ":childOrder";
+}

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeAware.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeAware.java
@@ -14,12 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jackrabbit.oak.plugins.tree.impl;
+package org.apache.jackrabbit.oak.plugins.tree;
 
-public interface TreeConstants {
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
-    /**
-     * Name of the internal property that contains the child order
-     */
-    String OAK_CHILD_ORDER = ":childOrder";
+public interface TreeTypeAware {
+
+    @CheckForNull
+    TreeType getType();
+
+    void setType(@Nonnull TreeType type);
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeProvider.java
@@ -20,8 +20,6 @@ import javax.annotation.Nonnull;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
-import org.apache.jackrabbit.oak.spi.version.VersionConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.apache.jackrabbit.oak.spi.version.VersionConstants;
 
@@ -38,11 +36,11 @@ public final class TreeTypeProvider {
             return TreeType.DEFAULT;
         } else {
             TreeType type;
-            if (tree instanceof ImmutableTree) {
-                type = ((ImmutableTree) tree).getType();
+            if (tree instanceof TreeTypeAware) {
+                type = ((TreeTypeAware) tree).getType();
                 if (type == null) {
                     type = internalGetType(tree);
-                    ((ImmutableTree) tree).setType(type);
+                    ((TreeTypeAware) tree).setType(type);
                 }
             } else {
                 type = internalGetType(tree);
@@ -57,11 +55,11 @@ public final class TreeTypeProvider {
         }
 
         TreeType type;
-        if (tree instanceof ImmutableTree) {
-            type = ((ImmutableTree) tree).getType();
+        if (tree instanceof TreeTypeAware) {
+            type = ((TreeTypeAware) tree).getType();
             if (type == null) {
                 type = internalGetType(tree, parentType);
-                ((ImmutableTree) tree).setType(type);
+                ((TreeTypeAware) tree).setType(type);
             }
         } else {
             type = internalGetType(tree, parentType);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeUtil.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/TreeUtil.java
@@ -41,7 +41,6 @@ import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.UUIDUtils;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
-import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
 import org.apache.jackrabbit.util.ISO8601;
 
 import static com.google.common.collect.Iterables.contains;
@@ -499,6 +498,6 @@ public final class TreeUtil {
      * @see org.apache.jackrabbit.oak.plugins.tree.RootFactory#createReadOnlyRoot(org.apache.jackrabbit.oak.spi.state.NodeState)
      */
     public static boolean isReadOnlyTree(@Nonnull Tree tree) {
-        return tree instanceof ImmutableTree;
+        return tree instanceof ReadOnly;
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractMutableTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractMutableTree.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
 import java.util.List;
 
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 
 /**
@@ -99,7 +100,7 @@ public abstract class AbstractMutableTree extends AbstractTree {
 
     /**
      * Updates the child order to match any added or removed child nodes that
-     * are not yet reflected in the {@link org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER}
+     * are not yet reflected in the {@link TreeConstants#OAK_CHILD_ORDER}
      * property. If the {@code force} flag is set, the child order is set
      * in any case, otherwise only if the node already is orderable.
      *

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -29,7 +29,7 @@ import static org.apache.jackrabbit.oak.api.Tree.Status.MODIFIED;
 import static org.apache.jackrabbit.oak.api.Tree.Status.NEW;
 import static org.apache.jackrabbit.oak.api.Tree.Status.UNCHANGED;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
 import java.util.Iterator;
 import java.util.List;
@@ -46,6 +46,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.reference.NodeReferenceConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.state.ConflictAnnotatingRebaseDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTree.java
@@ -25,7 +25,9 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.tree.ReadOnly;
 import org.apache.jackrabbit.oak.plugins.tree.TreeType;
+import org.apache.jackrabbit.oak.plugins.tree.TreeTypeAware;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.ReadOnlyBuilder;
@@ -78,7 +80,7 @@ import org.apache.jackrabbit.oak.spi.state.ReadOnlyBuilder;
  * however, that according to the contract defined in {@code NodeState} these
  * objects are not expected to be used as hash keys.
  */
-public final class ImmutableTree extends AbstractTree {
+public final class ImmutableTree extends AbstractTree implements TreeTypeAware, ReadOnly {
 
     /**
      * Underlying node state
@@ -110,11 +112,13 @@ public final class ImmutableTree extends AbstractTree {
         this.parentProvider = parentProvider;
     }
 
+    //----------------------------------------------------------< TypeAware >---
+    @CheckForNull
     public TreeType getType() {
         return type;
     }
 
-    public void setType(TreeType type) {
+    public void setType(@Nonnull TreeType type) {
         this.type = type;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionableState.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionableState.java
@@ -67,7 +67,7 @@ import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.plugins.nodetype.ReadOnlyNodeTypeManager;
 import org.apache.jackrabbit.oak.plugins.tree.TreeFactory;
 import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlValidator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlValidator.java
@@ -38,7 +38,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.nodetype.TypePredicate;
 import org.apache.jackrabbit.oak.plugins.tree.TreeFactory;
 import org.apache.jackrabbit.oak.plugins.tree.impl.AbstractTree;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.commit.DefaultValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
 import org.apache.jackrabbit.oak.spi.commit.VisibleValidator;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/ChildOrderDiff.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/ChildOrderDiff.java
@@ -22,12 +22,13 @@ import javax.annotation.CheckForNull;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 
 import static com.google.common.collect.Sets.newLinkedHashSet;
 
 /**
  * Helper class to handle modifications to the hidden
- * {@link org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER} property.
+ * {@link TreeConstants#OAK_CHILD_ORDER} property.
  */
 final class ChildOrderDiff {
 
@@ -35,7 +36,7 @@ final class ChildOrderDiff {
 
     /**
      * Tests if there was any user-supplied reordering involved with the
-     * modification of the {@link org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER}
+     * modification of the {@link TreeConstants#OAK_CHILD_ORDER}
      * property.
      *
      * @param before

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/PermissionStoreEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/PermissionStoreEditor.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 import static com.google.common.collect.Iterables.addAll;
 import static com.google.common.collect.Sets.newLinkedHashSet;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
 final class PermissionStoreEditor implements AccessControlConstants, PermissionConstants {
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/PermissionValidator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/PermissionValidator.java
@@ -29,7 +29,7 @@ import org.apache.jackrabbit.oak.plugins.tree.TreeFactory;
 import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
 import org.apache.jackrabbit.oak.plugins.lock.LockConstants;
 import org.apache.jackrabbit.oak.plugins.nodetype.TypePredicate;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.version.VersionConstants;
 import org.apache.jackrabbit.oak.spi.commit.DefaultValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistration.java
@@ -69,7 +69,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.newCopyOnWriteArrayList;
 import static org.apache.jackrabbit.oak.spi.security.RegistrationConstants.OAK_SECURITY_NAME;
 
-@Component
+@Component(immediate=true)
 @Designate(ocd = SecurityProviderRegistration.Configuration.class)
 @SuppressWarnings("unused")
 public class SecurityProviderRegistration {
@@ -141,8 +141,8 @@ public class SecurityProviderRegistration {
     //----------------------------------------------------< SCR integration >---
 
     @Activate
-    public void activate(BundleContext context, Map<String, Object> configuration) {
-        String[] requiredServicePids = getRequiredServicePids(configuration);
+    public void activate(BundleContext context, Configuration configuration) {
+        String[] requiredServicePids = configuration.requiredServicePids();
 
         synchronized (this) {
             for (String pid : requiredServicePids) {
@@ -151,14 +151,14 @@ public class SecurityProviderRegistration {
 
             this.context = context;
         }
-        this.authorizationConfiguration.withCompositionType(getAuthorizationCompositionType(configuration));
+        this.authorizationConfiguration.withCompositionType(configuration.authorizationCompositionType());
 
         maybeRegister();
     }
 
     @Modified
-    public void modified(Map<String, Object> configuration) {
-        String[] requiredServicePids = getRequiredServicePids(configuration);
+    public void modified(Configuration configuration) {
+        String[] requiredServicePids = configuration.requiredServicePids();
 
         synchronized (this) {
             preconditions.clearPreconditions();
@@ -167,7 +167,7 @@ public class SecurityProviderRegistration {
                 preconditions.addPrecondition(pid);
             }
         }
-        this.authorizationConfiguration.withCompositionType(getAuthorizationCompositionType(configuration));
+        this.authorizationConfiguration.withCompositionType(configuration.authorizationCompositionType());
 
         maybeUnregister();
         maybeRegister();
@@ -591,14 +591,5 @@ public class SecurityProviderRegistration {
             return servicePid;
         }
         return PropertiesUtil.toString(properties.get(OAK_SECURITY_NAME), null);
-    }
-
-    private static String[] getRequiredServicePids(Map<String, Object> configuration) {
-        return PropertiesUtil.toStringArray(configuration.get("requiredServicePids"), new String[]{});
-    }
-
-    @Nonnull
-    private static String getAuthorizationCompositionType(Map<String, Object> properties) {
-        return PropertiesUtil.toString(properties.get("authorizationCompositionType"), "AND");
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/security/Context.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/security/Context.java
@@ -22,7 +22,6 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.tree.TreeContext;
 import org.apache.jackrabbit.oak.plugins.tree.TreeLocation;
-import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * {@code Context} represents item related information in relation to a

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/importer/JsonDeserializationTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/importer/JsonDeserializationTest.java
@@ -28,7 +28,6 @@ import org.apache.jackrabbit.oak.json.Base64BlobSerializer;
 import org.apache.jackrabbit.oak.json.BlobSerializer;
 import org.apache.jackrabbit.oak.json.JsonDeserializer;
 import org.apache.jackrabbit.oak.json.JsonSerializer;
-import org.apache.jackrabbit.oak.json.JsopDiff;
 import org.apache.jackrabbit.oak.plugins.tree.TreeFactory;
 import org.apache.jackrabbit.oak.spi.state.EqualsDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/FilteringNodeStateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/FilteringNodeStateTest.java
@@ -42,7 +42,7 @@ import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.cre
 import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.commit;
 import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.createNodeStoreWithContent;
 import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.getNodeState;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeLocationTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeLocationTest.java
@@ -18,57 +18,93 @@
  */
 package org.apache.jackrabbit.oak.plugins.tree;
 
+import org.apache.jackrabbit.oak.api.Root;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
-import org.apache.jackrabbit.JcrConstants;
-import org.apache.jackrabbit.oak.AbstractSecurityTest;
-import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.util.NodeUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+public class TreeLocationTest {
 
-public class TreeLocationTest extends AbstractSecurityTest {
-
-    private TreeLocation nullLocation;
+    private Tree rootTree;
+    private Tree nonExisting;
+    private Root root;
 
     @Before
     public void setUp() throws Exception {
-        Tree tree = root.getTree("/");
-        tree.setProperty("a", 1);
-        tree.setProperty("b", 2);
-        tree.setProperty("c", 3);
 
-        NodeUtil n = new NodeUtil(tree);
-        n.addChild("x", JcrConstants.NT_UNSTRUCTURED);
-        n.addChild("y", JcrConstants.NT_UNSTRUCTURED);
-        n.addChild("z", JcrConstants.NT_UNSTRUCTURED).addChild("1", JcrConstants.NT_UNSTRUCTURED).addChild("2", JcrConstants.NT_UNSTRUCTURED).setString("p", "v");
-        root.commit();
+        rootTree = mockTree("/", null);
+        when(rootTree.hasProperty("p")).thenReturn(true);
+        when(rootTree.getProperty("p")).thenReturn(PropertyStates.createProperty("p", 1));
 
-        nullLocation = TreeLocation.create(root).getParent();
+        nonExisting = Mockito.mock(Tree.class);
+        when(nonExisting.exists()).thenReturn(false);
+        when(nonExisting.getName()).thenReturn("nonExisting");
+
+        Tree x = mockTree("/x", rootTree);
+        Tree subTree = mockTree("/z", rootTree);
+        Tree child = mockTree("/z/child", subTree);
+        when(child.hasProperty("p")).thenReturn(true);
+        when(child.getProperty("p")).thenReturn(PropertyStates.createProperty("p", "value"));
+
+        when(subTree.getChild("child")).thenReturn(child);
+        when(rootTree.getChild("z")).thenReturn(subTree);
+        when(rootTree.getChild("x")).thenReturn(x);
+
+        root = Mockito.mock(Root.class);
+        when(root.getTree("/")).thenReturn(rootTree);
     }
 
-    @After
-    public void tearDown() {
-        root = null;
+    private Tree mockTree(String path, Tree parent) {
+        Tree t = Mockito.mock(Tree.class);
+        when(t.getPath()).thenReturn(path);
+        when(t.getName()).thenReturn(PathUtils.getName(path));
+        if (PathUtils.denotesRoot(path)) {
+            when(t.getParent()).thenThrow(IllegalStateException.class);
+            when(t.isRoot()).thenReturn(true);
+        } else {
+            when(t.getParent()).thenReturn(parent);
+            when(t.isRoot()).thenReturn(false);
+        }
+        when(t.exists()).thenReturn(true);
+        when(t.hasProperty("nonExisting")).thenReturn(false);
+        when(t.hasChild("nonExisting")).thenReturn(false);
+        when(t.getChild("nonExisting")).thenReturn(nonExisting);
+        return t;
     }
 
     @Test
     public void testNullLocation() {
-        TreeLocation xyz = nullLocation.getChild("x").getChild("y").getChild("z");
-        Assert.assertEquals("x/y/z", xyz.getPath());
-        assertEquals("x/y", xyz.getParent().getPath());
-        assertEquals("x", xyz.getParent().getParent().getPath());
-        assertEquals(nullLocation, xyz.getParent().getParent().getParent());
+        TreeLocation nullLocation = TreeLocation.create(root).getParent();
+        assertNull(nullLocation.getTree());
+        assertTrue(nullLocation.getName().isEmpty());
+
+        TreeLocation child = nullLocation.getChild("any");
+        assertNotNull(child);
+        assertNull(child.getTree());
+        assertNull(child.getProperty());
+
+        TreeLocation child2 = nullLocation.getChild("x");
+        assertNotNull(child2);
+        assertNull(child.getTree());
+        assertNull(child.getProperty());
     }
 
     @Test
     public void testParentOfRoot() {
-        TreeLocation rootLocation = TreeLocation.create(root);
-        assertEquals(nullLocation, rootLocation.getParent());
+        TreeLocation nullLocation = TreeLocation.create(root).getParent();
+        assertSame(nullLocation, nullLocation.getParent());
+        assertTrue(nullLocation.getName().isEmpty());
     }
 
     @Test
@@ -76,46 +112,47 @@ public class TreeLocationTest extends AbstractSecurityTest {
         TreeLocation x = TreeLocation.create(root, "/x");
         assertNotNull(x.getTree());
 
-        TreeLocation xyz = x.getChild("y").getChild("z");
-        assertEquals("/x/y/z", xyz.getPath());
-        assertNull(xyz.getTree());
-
-        TreeLocation xy = xyz.getParent();
-        assertEquals("/x/y", xy.getPath());
-        assertNull(xy.getTree());
-
-        assertEquals(x.getTree(), xy.getParent().getTree());
+        assertEquals(rootTree, x.getParent().getTree());
     }
 
     @Test
     public void testPropertyLocation() {
-        TreeLocation a = TreeLocation.create(root, "/a");
-        assertNotNull(a.getProperty());
+        TreeLocation propLocation = TreeLocation.create(root, "/p");
+        assertNotNull(propLocation.getProperty());
 
-        TreeLocation abc = a.getChild("b").getChild("c");
-        assertEquals("/a/b/c", abc.getPath());
+        TreeLocation abc = propLocation.getChild("b").getChild("c");
+        assertEquals("/p/b/c", abc.getPath());
         assertNull(abc.getProperty());
 
         TreeLocation ab = abc.getParent();
-        assertEquals("/a/b", ab.getPath());
+        assertEquals("/p/b", ab.getPath());
         assertNull(ab.getProperty());
 
-        assertEquals(a.getProperty(), ab.getParent().getProperty());
+        assertEquals(propLocation.getProperty(), ab.getParent().getProperty());
     }
 
     @Test
     public void getDeepLocation() {
-        TreeLocation p = TreeLocation.create(root, "/z/1/2/p");
-        assertNotNull(p.getProperty());
-        assertEquals("/z/1/2/p", p.getPath());
+        TreeLocation child = TreeLocation.create(root, "/z/child");
+        assertNotNull(child.getTree());
+        assertNull(child.getProperty());
 
-        TreeLocation n = TreeLocation.create(root, "/z/1/2/3/4");
+        TreeLocation p = TreeLocation.create(root, "/z/child/p");
+        assertNotNull(p.getProperty());
+        assertNull(p.getTree());
+        assertEquals("/z/child/p", p.getPath());
+
+        TreeLocation n = TreeLocation.create(root, "/z/child/p/3/4");
         assertNull(n.getTree());
         assertNull(n.getProperty());
-        assertEquals("/z/1/2/3/4", n.getPath());
+        assertEquals("/z/child/p/3/4", n.getPath());
 
-        TreeLocation two = n.getParent().getParent();
-        assertNotNull(two.getTree());
-        assertEquals("/z/1/2", two.getPath());
+        TreeLocation t = n.getParent().getParent();
+        assertNull(t.getTree());
+        assertNotNull(t.getProperty());
+
+        TreeLocation t2 = t.getParent();
+        assertNotNull(t2.getTree());
+        assertEquals("/z/child", t2.getPath());
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeProviderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeTypeProviderTest.java
@@ -21,30 +21,54 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.apache.jackrabbit.JcrConstants;
-import org.apache.jackrabbit.oak.AbstractSecurityTest;
+import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
 import org.apache.jackrabbit.oak.spi.version.VersionConstants;
-import org.apache.jackrabbit.oak.spi.security.authorization.AuthorizationConfiguration;
-import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
-import org.apache.jackrabbit.oak.spi.security.authorization.permission.PermissionConstants;
-import org.apache.jackrabbit.oak.util.NodeUtil;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.when;
 
-public class TreeTypeProviderTest extends AbstractSecurityTest {
+public class TreeTypeProviderTest {
 
     private TreeTypeProvider typeProvider;
 
     private List<TypeTest> tests;
 
-    @Override
+    @Before
     public void before() throws Exception {
-        super.before();
+        typeProvider = new TreeTypeProvider(new TreeContext(){
 
-        typeProvider = new TreeTypeProvider(getConfig(AuthorizationConfiguration.class).getContext());
+            @Override
+            public boolean definesProperty(@Nonnull Tree parent, @Nonnull PropertyState property) {
+                return false;
+            }
+
+            @Override
+            public boolean definesContextRoot(@Nonnull Tree tree) {
+                return false;
+            }
+
+            @Override
+            public boolean definesTree(@Nonnull Tree tree) {
+                return false;
+            }
+
+            @Override
+            public boolean definesLocation(@Nonnull TreeLocation location) {
+                return false;
+            }
+
+            @Override
+            public boolean definesInternal(@Nonnull Tree tree) {
+                return false;
+            }
+        });
 
         tests = new ArrayList<TypeTest>();
         tests.add(new TypeTest("/", TreeType.DEFAULT));
@@ -54,12 +78,6 @@ public class TreeTypeProviderTest extends AbstractSecurityTest {
         tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:system/rep:namedChildNodeDefinitions/jcr:versionStorage", TreeType.DEFAULT));
         tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:system/rep:namedChildNodeDefinitions/jcr:activities", TreeType.DEFAULT));
         tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:system/rep:namedChildNodeDefinitions/jcr:configurations", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:AccessControllable/rep:namedChildNodeDefinitions/rep:policy", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:AccessControllable/rep:namedChildNodeDefinitions/rep:policy/rep:Policy", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:ACL/rep:residualChildNodeDefinitions/rep:ACE", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:GrantACE/rep:namedChildNodeDefinitions/rep:restrictions", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:RepoAccessControllable/rep:namedChildNodeDefinitions/rep:repoPolicy", TreeType.DEFAULT));
-        tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:PermissionStore", TreeType.DEFAULT));
 
         tests.add(new TypeTest("/:hidden", TreeType.HIDDEN));
         tests.add(new TypeTest("/:hidden/child", TreeType.HIDDEN, TreeType.HIDDEN));
@@ -71,56 +89,41 @@ public class TreeTypeProviderTest extends AbstractSecurityTest {
             tests.add(new TypeTest(versionPath, TreeType.VERSION));
             tests.add(new TypeTest(versionPath + "/a/b/child", TreeType.VERSION, TreeType.VERSION));
         }
-
-        tests.add(new TypeTest(PermissionConstants.PERMISSIONS_STORE_PATH, TreeType.INTERNAL));
-        tests.add(new TypeTest(PermissionConstants.PERMISSIONS_STORE_PATH + "/a/b/child", TreeType.INTERNAL, TreeType.INTERNAL));
-
-        NodeUtil testTree = new NodeUtil(root.getTree("/")).addChild("test", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
-        for (String name : AccessControlConstants.POLICY_NODE_NAMES) {
-            NodeUtil acl = testTree.addChild(name, AccessControlConstants.NT_REP_ACL);
-            tests.add(new TypeTest(acl.getTree().getPath(), TreeType.ACCESS_CONTROL));
-
-            NodeUtil ace = acl.addChild("ace", AccessControlConstants.NT_REP_DENY_ACE);
-            tests.add(new TypeTest(ace.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
-
-            NodeUtil ace2 = acl.addChild("ace2", AccessControlConstants.NT_REP_GRANT_ACE);
-            tests.add(new TypeTest(ace2.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
-
-            NodeUtil rest = ace2.addChild(AccessControlConstants.REP_RESTRICTIONS, AccessControlConstants.NT_REP_RESTRICTIONS);
-            tests.add(new TypeTest(rest.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
-
-            NodeUtil invalid = rest.addChild("invalid", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
-            tests.add(new TypeTest(invalid.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
-        }
     }
 
-    @Override
-    public void after() throws Exception {
-        try {
-            root.refresh();
-        } finally {
-            super.after();
+    private static Tree mockTree(@Nonnull String path) {
+        Tree t = Mockito.mock(Tree.class);
+        when(t.getPath()).thenReturn(path);
+        when(t.getName()).thenReturn(PathUtils.getName(path));
+        if (PathUtils.denotesRoot(path)) {
+            when(t.getParent()).thenThrow(IllegalStateException.class);
+            when(t.isRoot()).thenReturn(true);
+        } else {
+            Tree parent = mockTree(PathUtils.getAncestorPath(path, 1));
+            when(t.getParent()).thenReturn(parent);
+            when(t.isRoot()).thenReturn(false);
         }
+        return t;
     }
 
     @Test
     public void testGetType() {
         for (TypeTest test : tests) {
-            assertEquals(test.path, test.type, typeProvider.getType(root.getTree(test.path)));
+            assertEquals(test.path, test.type, typeProvider.getType(mockTree(test.path)));
         }
     }
 
     @Test
     public void testGetTypeWithParentType() {
         for (TypeTest test : tests) {
-            assertEquals(test.path, test.type, typeProvider.getType(root.getTree(test.path), test.parentType));
+            assertEquals(test.path, test.type, typeProvider.getType(mockTree(test.path), test.parentType));
         }
     }
 
     @Test
     public void testGetTypeWithDefaultParentType() {
         for (TypeTest test : tests) {
-            TreeType typeIfParentDefault = typeProvider.getType(root.getTree(test.path), TreeType.DEFAULT);
+            TreeType typeIfParentDefault = typeProvider.getType(mockTree(test.path), TreeType.DEFAULT);
 
             if (TreeType.DEFAULT == test.parentType) {
                 assertEquals(test.path, test.type, typeIfParentDefault);
@@ -132,7 +135,7 @@ public class TreeTypeProviderTest extends AbstractSecurityTest {
 
     @Test
     public void testGetTypeForRootTree() {
-        Tree t = root.getTree("/");
+        Tree t = mockTree(PathUtils.ROOT_PATH);
         assertEquals(TreeType.DEFAULT, typeProvider.getType(t));
 
         // the type of the root tree is always 'DEFAULT' irrespective of the passed parent type.
@@ -141,32 +144,6 @@ public class TreeTypeProviderTest extends AbstractSecurityTest {
         assertEquals(TreeType.DEFAULT, typeProvider.getType(t, TreeType.VERSION));
     }
 
-    @Test
-    public void testGetTypeForImmutableTree() {
-        for (String path : new String[] {"/", "/testPath"}) {
-            Tree t = RootFactory.createReadOnlyRoot(root).getTree(path);
-            assertEquals(TreeType.DEFAULT, typeProvider.getType(t));
-            // also for repeated calls
-            assertEquals(TreeType.DEFAULT, typeProvider.getType(t));
-
-            // the type of an immutable tree is set after the first call irrespective of the passed parent type.
-            assertEquals(TreeType.DEFAULT, typeProvider.getType(t, TreeType.DEFAULT));
-            assertEquals(TreeType.DEFAULT, typeProvider.getType(t, TreeType.HIDDEN));
-        }
-    }
-
-    @Test
-    public void testGetTypeForImmutableTreeWithParent() {
-        Tree t = RootFactory.createReadOnlyRoot(root).getTree("/:hidden/testPath");
-        assertEquals(TreeType.HIDDEN, typeProvider.getType(t, TreeType.HIDDEN));
-
-        // the type of an immutable tree is set after the first call irrespective of the passed parent type.
-        assertEquals(TreeType.HIDDEN, typeProvider.getType(t));
-        assertEquals(TreeType.HIDDEN, typeProvider.getType(t, TreeType.DEFAULT));
-        assertEquals(TreeType.HIDDEN, typeProvider.getType(t, TreeType.ACCESS_CONTROL));
-        assertEquals(TreeType.HIDDEN, typeProvider.getType(t, TreeType.VERSION));
-    }
-    
     private static final class TypeTest {
 
         private final String path;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/AuthorizationContextTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/AuthorizationContextTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.jackrabbit.oak.security.authorization;
 
+import java.util.ArrayList;
 import java.util.List;
-
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.jcr.RepositoryException;
 import javax.jcr.security.AccessControlList;
@@ -28,17 +29,24 @@ import com.google.common.collect.Lists;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
+import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.tree.TreeLocation;
+import org.apache.jackrabbit.oak.plugins.tree.TreeType;
+import org.apache.jackrabbit.oak.plugins.tree.TreeTypeProvider;
+import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
 import org.apache.jackrabbit.oak.spi.security.Context;
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.PermissionConstants;
 import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
+import org.apache.jackrabbit.oak.util.NodeUtil;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -141,4 +149,84 @@ public class AuthorizationContextTest extends AbstractSecurityTest {
         }
     }
 
+    @Test
+    public void testGetType() throws Exception {
+        TreeTypeProvider ttp = new TreeTypeProvider(AuthorizationContext.getInstance());
+        for (TypeTest test : TypeTest.createTests(root)) {
+            assertEquals(test.path, test.type, ttp.getType(root.getTree(test.path)));
+        }
+    }
+
+    @Test
+    public void testGetTypeWithParentType() throws Exception {
+        TreeTypeProvider ttp = new TreeTypeProvider(AuthorizationContext.getInstance());
+        for (TypeTest test : TypeTest.createTests(root)) {
+            assertEquals(test.path, test.type, ttp.getType(root.getTree(test.path), test.parentType));
+        }
+    }
+
+    @Test
+    public void testGetTypeWithDefaultParentType() throws Exception {
+        TreeTypeProvider ttp = new TreeTypeProvider(AuthorizationContext.getInstance());
+        for (TypeTest test : TypeTest.createTests(root)) {
+            TreeType typeIfParentDefault = ttp.getType(root.getTree(test.path), TreeType.DEFAULT);
+
+            if (TreeType.DEFAULT == test.parentType) {
+                assertEquals(test.path, test.type, typeIfParentDefault);
+            } else {
+                assertNotEquals(test.path, test.type, typeIfParentDefault);
+            }
+        }
+    }
+
+
+    private static final class TypeTest {
+
+        private final String path;
+        private final TreeType type;
+        private final TreeType parentType;
+
+        private TypeTest(@Nonnull String path, TreeType type) {
+            this(path, type, TreeType.DEFAULT);
+        }
+
+        private TypeTest(@Nonnull String path, TreeType type, TreeType parentType) {
+            this.path = path;
+            this.type = type;
+            this.parentType = parentType;
+        }
+
+        private static List<TypeTest> createTests(@Nonnull Root root) throws Exception {
+            List<TypeTest> tests = new ArrayList();
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:AccessControllable/rep:namedChildNodeDefinitions/rep:policy", TreeType.DEFAULT));
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:AccessControllable/rep:namedChildNodeDefinitions/rep:policy/rep:Policy", TreeType.DEFAULT));
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:ACL/rep:residualChildNodeDefinitions/rep:ACE", TreeType.DEFAULT));
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:GrantACE/rep:namedChildNodeDefinitions/rep:restrictions", TreeType.DEFAULT));
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:RepoAccessControllable/rep:namedChildNodeDefinitions/rep:repoPolicy", TreeType.DEFAULT));
+            tests.add(new TypeTest(NodeTypeConstants.NODE_TYPES_PATH + "/rep:PermissionStore", TreeType.DEFAULT));
+
+
+            tests.add(new TypeTest(PermissionConstants.PERMISSIONS_STORE_PATH, TreeType.INTERNAL));
+            tests.add(new TypeTest(PermissionConstants.PERMISSIONS_STORE_PATH + "/a/b/child", TreeType.INTERNAL, TreeType.INTERNAL));
+
+            NodeUtil testTree = new NodeUtil(root.getTree("/")).addChild("test", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
+            for (String name : AccessControlConstants.POLICY_NODE_NAMES) {
+                NodeUtil acl = testTree.addChild(name, AccessControlConstants.NT_REP_ACL);
+                tests.add(new TypeTest(acl.getTree().getPath(), TreeType.ACCESS_CONTROL));
+
+                NodeUtil ace = acl.addChild("ace", AccessControlConstants.NT_REP_DENY_ACE);
+                tests.add(new TypeTest(ace.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
+
+                NodeUtil ace2 = acl.addChild("ace2", AccessControlConstants.NT_REP_GRANT_ACE);
+                tests.add(new TypeTest(ace2.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
+
+                NodeUtil rest = ace2.addChild(AccessControlConstants.REP_RESTRICTIONS, AccessControlConstants.NT_REP_RESTRICTIONS);
+                tests.add(new TypeTest(rest.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
+
+                NodeUtil invalid = rest.addChild("invalid", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
+                tests.add(new TypeTest(invalid.getTree().getPath(), TreeType.ACCESS_CONTROL, TreeType.ACCESS_CONTROL));
+            }
+            return tests;
+        }
+    }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
@@ -34,13 +34,13 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test for the hidden {@link org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER} property
+ * Test for the hidden {@link TreeConstants#OAK_CHILD_ORDER} property
  */
 public class ChildOrderPropertyTest extends AbstractOakCoreTest {
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/HiddenPropertyTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/HiddenPropertyTest.java
@@ -23,7 +23,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyBuilder;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for the hidden {@link org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants#OAK_CHILD_ORDER} property
+ * Test for the hidden {@link TreeConstants#OAK_CHILD_ORDER} property
  */
 public class HiddenPropertyTest extends AbstractOakCoreTest {
 

--- a/oak-it-osgi/README.md
+++ b/oak-it-osgi/README.md
@@ -1,0 +1,14 @@
+Oak Integration tests for OSGi deployments
+==
+
+This modules validates basic Oak functionality in an OSGi environment.
+
+The Oak modules under test are not picked up from the reactor build. Instead,
+they are read from the local repository and copied in a well-known location
+using the maven-assembly-plugin.
+
+In order to test a change made in a different module, you would need to:
+
+* Run `mvn install` in the changed module
+* Run `mvn assembly:single` in this module
+* Re-run the test(s) in this module

--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -39,19 +39,19 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>test-bundles.xml</descriptor>
+          </descriptors>
+          <finalName>test</finalName>
+          <attach>false</attach>
+        </configuration>
         <executions>
           <execution>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>single</goal>
             </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>test-bundles.xml</descriptor>
-              </descriptors>
-              <finalName>test</finalName>
-              <attach>false</attach>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>4.2.1</version>
+      <version>5.6.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-it-osgi/src/test/java/org/apache/jackrabbit/oak/osgi/OSGiIT.java
+++ b/oak-it-osgi/src/test/java/org/apache/jackrabbit/oak/osgi/OSGiIT.java
@@ -56,8 +56,9 @@ public class OSGiIT {
     public Option[] configuration() throws IOException, URISyntaxException {
         return CoreOptions.options(
                 junitBundles(),
-                mavenBundle("org.apache.felix", "org.apache.felix.scr", "1.8.0"),
-                mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", "1.4.0" ),
+                mavenBundle("org.apache.felix", "org.apache.felix.scr", "2.0.12"),
+                mavenBundle("org.osgi", "org.osgi.dto", "1.0.0"),
+                mavenBundle( "org.apache.felix", "org.apache.felix.configadmin", "1.8.16" ),
                 mavenBundle( "org.apache.felix", "org.apache.felix.fileinstall", "3.2.6" ),
                 mavenBundle( "org.ops4j.pax.logging", "pax-logging-api", "1.7.2" ),
                 frameworkProperty("repository.home").value("target"),

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/core/MutableTreeTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/core/MutableTreeTest.java
@@ -43,7 +43,7 @@ import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.memory.LongPropertyState;
 import org.apache.jackrabbit.oak.plugins.memory.StringBasedBlob;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/HiddenNodeTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/HiddenNodeTest.java
@@ -29,7 +29,7 @@ import javax.jcr.version.VersionManager;
 
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.jcr.Jcr;
-import org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants;
+import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.version.VersionConstants;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
 import org.apache.jackrabbit.oak.segment.memory.MemoryStore;

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexDefinition.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexDefinition.java
@@ -101,7 +101,7 @@ import static org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants.NODE_TYPE
 public final class IndexDefinition implements Aggregate.AggregateMapper {
     /**
      * Name of the internal property that contains the child order defined in
-     * org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants
+     * org.apache.jackrabbit.oak.plugins.tree.TreeConstants
      */
     private static final String OAK_CHILD_ORDER = ":childOrder";
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexDefinitionTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexDefinitionTest.java
@@ -62,7 +62,7 @@ import static org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexHel
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 import static org.apache.jackrabbit.oak.InitialContent.INITIAL_CONTENT;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/NodeStateAnalyzerFactoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/NodeStateAnalyzerFactoryTest.java
@@ -55,7 +55,7 @@ import static org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstant
 import static org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants.ANL_FILTERS;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants.ANL_TOKENIZER;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/oak-pojosr/pom.xml
+++ b/oak-pojosr/pom.xml
@@ -86,6 +86,16 @@
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <version>6.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.cmpn</artifactId>
+      <version>6.0.0</version>
+    </dependency>
   
     <!-- Pojo SR -->
     <!-- Added first to ensure that in an IDE the transitive dependencies of the oak modules
@@ -149,7 +159,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.scr</artifactId>
-      <version>1.8.2</version>
+      <version>2.0.12</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.mojo</groupId>
@@ -158,9 +168,14 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.dto</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.configadmin</artifactId>
-      <version>1.8.6</version>
+      <version>1.8.16</version>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>

--- a/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/AbstractRepositoryFactoryTest.groovy
+++ b/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/AbstractRepositoryFactoryTest.groovy
@@ -31,6 +31,9 @@ import org.osgi.framework.ServiceEvent
 import org.osgi.framework.ServiceListener
 import org.osgi.framework.ServiceReference
 import org.osgi.service.cm.ConfigurationAdmin
+import org.osgi.service.component.runtime.ServiceComponentRuntime
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
+import org.osgi.util.promise.Promise
 import org.osgi.util.tracker.ServiceTracker
 
 import javax.jcr.*
@@ -222,5 +225,25 @@ abstract class AbstractRepositoryFactoryTest{
         } finally {
             registry.removeServiceListener(listener)
         }
+    }
+
+    protected void disableComponent(String name) {
+        ServiceComponentRuntime scr = getServiceWithWait(ServiceComponentRuntime.class)
+        ComponentDescriptionDTO dto = getComponentDTO(scr, name)
+        Promise p = scr.disableComponent(dto)
+        p.getValue() //Block on get
+    }
+
+    protected void enableComponent(String name) {
+        ServiceComponentRuntime scr = getServiceWithWait(ServiceComponentRuntime.class)
+        ComponentDescriptionDTO dto = getComponentDTO(scr, name)
+        Promise p = scr.enableComponent(dto)
+        p.getValue() //Block on get
+    }
+
+    ComponentDescriptionDTO getComponentDTO(ServiceComponentRuntime scr, String name) {
+        ComponentDescriptionDTO dto = scr.getComponentDescriptionDTOs().find {ComponentDescriptionDTO d -> (d.name == name) }
+        assert dto : "No component found with name $name"
+        return dto
     }
 }

--- a/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/PropertyIndexReindexingTest.groovy
+++ b/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/PropertyIndexReindexingTest.groovy
@@ -20,8 +20,6 @@
 package org.apache.jackrabbit.oak.run.osgi
 
 import org.apache.felix.connect.launch.PojoServiceRegistry
-import org.apache.felix.scr.Component
-import org.apache.felix.scr.ScrService
 import org.apache.jackrabbit.JcrConstants
 import org.apache.jackrabbit.commons.JcrUtils
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants
@@ -66,17 +64,14 @@ class PropertyIndexReindexingTest extends AbstractRepositoryFactoryTest{
         s.logout()
 
         //4. Disable the PropertyIndexEditor
-        ScrService scr = getService(ScrService.class)
-        Component[] c = scr.getComponents('org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexEditorProvider')
-        assert c
-
-        c[0].disable()
+        def indexComponent = 'org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexEditorProvider'
+        disableComponent(indexComponent)
         TimeUnit.SECONDS.sleep(1)
        assert registry.getServiceReference(Repository.class.name) == null : "Repository should be unregistered " +
                "if no property index editor found"
 
         //5. Re-enable the editor and wait untill repository gets re-registered
-        c[0].enable()
+        enableComponent(indexComponent)
         getServiceWithWait(Repository.class, registry.bundleContext)
 
         //6. Reindex flag should be stable

--- a/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/RepositoryClosedTest.groovy
+++ b/oak-pojosr/src/test/groovy/org/apache/jackrabbit/oak/run/osgi/RepositoryClosedTest.groovy
@@ -21,16 +21,12 @@ package org.apache.jackrabbit.oak.run.osgi
 
 import groovy.util.logging.Slf4j
 import org.apache.felix.connect.launch.PojoServiceRegistry
-import org.apache.felix.scr.Component
-import org.apache.felix.scr.ScrService
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 import javax.jcr.RepositoryException
 import javax.jcr.Session
-import java.util.concurrent.TimeUnit
 
 import static org.apache.jackrabbit.oak.run.osgi.OakOSGiRepositoryFactory.REPOSITORY_CONFIG_FILE
 
@@ -51,10 +47,9 @@ class RepositoryClosedTest extends AbstractRepositoryFactoryTest{
         Session s = createAdminSession()
 
         //2 Trigger repository shutdown
-        disableComponents(
-                'org.apache.jackrabbit.oak.jcr.osgi.RepositoryManager',
-                'org.apache.jackrabbit.oak.plugins.name.NameValidatorProvider'
-        )
+        disableComponent('org.apache.jackrabbit.oak.jcr.osgi.RepositoryManager')
+        disableComponent('org.apache.jackrabbit.oak.plugins.name.NameValidatorProvider')
+
         log.info("Repository shutdown complete. Proceeding with save")
 
         //Null out repository to prevent shutdown attempt in teardown
@@ -74,15 +69,4 @@ class RepositoryClosedTest extends AbstractRepositoryFactoryTest{
         OakOSGiRepositoryFactory.shutdown(registry, 5)
     }
 
-    private void disableComponents(String ... names){
-        ScrService scr = getService(ScrService.class)
-        names.each {String name ->
-            Component[] c = scr.getComponents(name)
-            assert c : "No component with name '$name' found"
-            c[0].componentInstance?.dispose()
-            log.info("Disabling {}", name)
-        }
-
-        TimeUnit.SECONDS.sleep(1)
-    }
 }

--- a/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactoryTest.java
+++ b/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactoryTest.java
@@ -85,7 +85,7 @@ public class OakOSGiRepositoryFactoryTest {
         copyConfig("common");
     }
 
-    @Test(timeout = 60)
+    @Test(timeout = 60 * 1000)
     public void testRepositoryTar() throws Exception {
         copyConfig("tar");
         config.put(BundleActivator.class.getName(), new TestActivator());

--- a/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactoryTest.java
+++ b/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactoryTest.java
@@ -85,7 +85,7 @@ public class OakOSGiRepositoryFactoryTest {
         copyConfig("common");
     }
 
-    @Test
+    @Test(timeout = 60)
     public void testRepositoryTar() throws Exception {
         copyConfig("tar");
         config.put(BundleActivator.class.getName(), new TestActivator());

--- a/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/SimpleRepositoryFactoryTest.java
+++ b/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/SimpleRepositoryFactoryTest.java
@@ -41,7 +41,7 @@ public class SimpleRepositoryFactoryTest {
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder(new File("target"));
 
-    @Test
+    @Test(timeout = 60)
     public void testRepositoryService() throws Exception{
         Map<String,String> config = new HashMap<String, String>();
         config.put("org.apache.jackrabbit.repository.home",

--- a/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/SimpleRepositoryFactoryTest.java
+++ b/oak-pojosr/src/test/java/org/apache/jackrabbit/oak/run/osgi/SimpleRepositoryFactoryTest.java
@@ -41,7 +41,7 @@ public class SimpleRepositoryFactoryTest {
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder(new File("target"));
 
-    @Test(timeout = 60)
+    @Test(timeout = 60 * 1000)
     public void testRepositoryService() throws Exception{
         Map<String,String> config = new HashMap<String, String>();
         config.put("org.apache.jackrabbit.repository.home",

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -295,7 +295,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.14.2</version>
+      <version>2.14.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBBlobStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBBlobStore.java
@@ -182,11 +182,11 @@ public class RDBBlobStore extends CachingBlobStore implements Closeable {
 
         try {
             for (String tableName : new String[] { this.tnData, this.tnMeta }) {
-                PreparedStatement checkStatement = null;
+                Statement checkStatement = null;
                 try {
-                    checkStatement = con.prepareStatement("select ID from " + tableName + " where ID = ?");
-                    checkStatement.setString(1, "0");
-                    checkStatement.executeQuery().close();
+                    // avoid PreparedStatement due to weird DB2 behavior (OAK-6237)
+                    checkStatement = con.createStatement();
+                    checkStatement.executeQuery("select ID from " + tableName + " where ID = '0'").close();
                     checkStatement.close();
                     checkStatement = null;
                     con.commit();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
@@ -1042,15 +1042,15 @@ public class RDBDocumentStore implements DocumentStore {
         }
         String tableName = tmd.getName();
 
-        PreparedStatement checkStatement = null;
+        Statement checkStatement = null;
 
         ResultSet checkResultSet = null;
         Statement creatStatement = null;
         Statement upgradeStatement = null;
         try {
-            checkStatement = con.prepareStatement("select * from " + tableName + " where ID = ?");
-            checkStatement.setString(1, "0:/");
-            checkResultSet = checkStatement.executeQuery();
+            // avoid PreparedStatement due to weird DB2 behavior (OAK-6237)
+            checkStatement = con.createStatement();
+            checkResultSet = checkStatement.executeQuery("select * from " + tableName + " where ID = '0'");
 
             // try to discover size of DATA column and binary-ness of ID
             ResultSetMetaData met = checkResultSet.getMetaData();

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
@@ -3146,7 +3146,6 @@ public class DocumentNodeStoreTest {
 
     // OAK-6392
     @Test
-    @Ignore("OAK-6680")
     public void disabledBranchesWithBackgroundWrite() throws Exception {
         final Thread current = Thread.currentThread();
         final Set<Integer> updates = Sets.newHashSet();
@@ -3185,12 +3184,18 @@ public class DocumentNodeStoreTest {
         });
         bgThread.start();
 
-        for (int j = 0; j < 20; j++) {
+        // perform up to 200 merges
+        for (int j = 0; j < 200; j++) {
             builder = ns.getRoot().builder();
             for (int i = 0; i < 30; i++) {
                 builder.child("node-" + i).child("test").setProperty("p", j);
             }
             merge(ns, builder);
+
+            // break out after 20 when there are updates
+            if (j > 20 && !updates.isEmpty()) {
+                break;
+            }
         }
         running.set(false);
         bgThread.join();

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/JackrabbitNodeState.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/JackrabbitNodeState.java
@@ -43,7 +43,7 @@ import static org.apache.jackrabbit.core.RepositoryImpl.VERSION_STORAGE_NODE_ID;
 import static org.apache.jackrabbit.oak.api.Type.NAME;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
-import static org.apache.jackrabbit.oak.plugins.tree.impl.TreeConstants.OAK_CHILD_ORDER;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;


### PR DESCRIPTION
This includes the recent SCR 1.3 fixes for OAK-6736 and OAK-6739 and the conversion fix in https://github.com/jsedding/jackrabbit-oak/commit/96b27ee68c5ed7b4f6819891ffc9aa6d3333d9c6 . With this we should be good to go with oak-core and oak-store-document